### PR TITLE
send referer on cross-origin requests

### DIFF
--- a/racial_covenants_processor/templates/cotton/layouts/base.html
+++ b/racial_covenants_processor/templates/cotton/layouts/base.html
@@ -5,6 +5,7 @@
 	<head>
 		<title>The Deed Machine - By Mapping Prejudice</title>
 		<meta charset="utf-8" />
+		<meta name="referrer" content="strict-origin-when-cross-origin" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/kelpui@1/css/kelp.css">
     <link href="{% static 'css/deed-machine.css' %}" rel="stylesheet" media="screen">


### PR DESCRIPTION
OSM [requires you to send referer headers](https://wiki.openstreetmap.org/wiki/Referer) when using their tiles. Since we don't directly control the fetch request (maplibre does this for us), we set a global `<meta>` tag that sends the referer on cross-origin requests, so long as the request is to an https domain. See the docs on the `<meta>` tag [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/referrer).