### PR TITLE
correctly namespace result template

### DIFF
--- a/racial_covenants_processor/templates/search/search.html
+++ b/racial_covenants_processor/templates/search/search.html
@@ -25,7 +25,7 @@
     <div class="box alt">
         <div class="row gtr-50 gtr-uniform">
         {% for result in page_obj.object_list %}
-          <c-result :result="result" /> 
+          <c-search.result :result="result" />
         {% empty %}
             <p>No results found.</p>
         {% endfor %}


### PR DESCRIPTION
The result cotton template is namespaced under search, so we need to find it there in the parent search template.