### PR TITLE
feat(search): migrate deed search index to OpenSearch client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 AWS_ACCESS_KEY_ID= # get from an account admin
 AWS_SECRET_ACCESS_KEY= # get from an account admin
 
-ELASTICSEARCH_PASSWORD= # get from terminal output after installing elasticsearch (see docs/modules/installation.rst)
-ELASTICSEARCH_API_KEY= # get from terminal output after installing elasticsearch (see docs/modules/installation.rst)
+OPENSEARCH_URL= # OpenSearch endpoint, e.g. https://search-xxx.us-east-2.es.amazonaws.com (https implies SSL); use http://localhost:9200 for a local container
+OPENSEARCH_USERNAME= # master user (optional; defaults to "admin")
+OPENSEARCH_PASSWORD= # master user password; also enables real-time signal indexing on save

--- a/Pipfile
+++ b/Pipfile
@@ -44,9 +44,8 @@ django-compressor = "*"
 typing-extensions = "*"
 django-libsass = "*"
 django-cotton = "*"
-django-elasticsearch-dsl = "==8.2"
-elasticsearch-dsl = "==8.18.0"
-elasticsearch = "==8.19.3"
+django-opensearch-dsl = "==0.8.0"
+opensearch-py = ">=2.2.0,<3"
 
 [dev-packages]
 csvkit = "*"

--- a/apps/deed/documents.py
+++ b/apps/deed/documents.py
@@ -1,5 +1,5 @@
-from django_elasticsearch_dsl import Document, fields
-from django_elasticsearch_dsl.registries import registry
+from django_opensearch_dsl import Document, fields
+from django_opensearch_dsl.registries import registry
 
 from apps.deed.models import DeedPage
 

--- a/apps/deed/documents.py
+++ b/apps/deed/documents.py
@@ -45,6 +45,52 @@ class DeedPageDocument(Document):
         # This uses the prefetched data from get_queryset()
         return [{'term': term.term} for term in instance.matched_terms.all()]
 
+    def get_indexing_queryset(self, verbose=False, filter_=None, exclude=None,
+                              alias=None, count=None, action=None, stdout=None):
+        """Stream the indexing queryset using keyset (seek) pagination.
+
+        django-opensearch-dsl's default ``get_indexing_queryset`` paginates with
+        ``qs[i:i + chunk_size]`` (SQL OFFSET), which is O(offset) per chunk and so
+        degrades quadratically when indexing millions of rows. Its
+        ``Document.get_queryset`` also uses a plain ``model.objects.all()`` that
+        bypasses the ``Django.get_queryset`` optimization, causing N+1 queries in
+        ``prepare_workflow`` / ``prepare_matched_terms``.
+
+        This override fixes both: it seeks by primary key (``pk > last_pk``,
+        O(chunk_size) via the PK index, so throughput stays flat at any depth) over
+        a queryset that ``select_related`` the workflow and ``prefetch_related`` the
+        matched terms. ``--filter`` / ``--exclude`` are honored; ``--count`` (which
+        applies a global LIMIT) falls back to the library default.
+        """
+        if count is not None:
+            kwargs = {"verbose": verbose, "filter_": filter_, "exclude": exclude,
+                      "alias": alias, "count": count}
+            if action is not None:
+                kwargs["action"] = action
+            if stdout is not None:
+                kwargs["stdout"] = stdout
+            yield from super().get_indexing_queryset(**kwargs)
+            return
+
+        qs = self.django.model.objects
+        if alias:
+            qs = qs.using(alias)
+        qs = qs.select_related("workflow").prefetch_related("matched_terms")
+        if filter_:
+            qs = qs.filter(filter_)
+        if exclude:
+            qs = qs.exclude(exclude)
+        qs = qs.order_by("pk")
+
+        chunk_size = self.django.queryset_pagination
+        last_pk = None
+        while True:
+            chunk = list((qs.filter(pk__gt=last_pk) if last_pk is not None else qs)[:chunk_size])
+            if not chunk:
+                break
+            yield from chunk
+            last_pk = chunk[-1].pk
+
     class Index:
         name = "deed_pages"
     class Django:

--- a/apps/deed/views.py
+++ b/apps/deed/views.py
@@ -40,8 +40,10 @@ class PaginatedElasticSearchAPIView(ModelViewSet, LimitOffsetPagination):
                 search_terms_list=search_terms, param_filters=params
             )
 
-            search = self.document_class.search().query(query)
-            
+            # track_total_hits=True returns the exact total hit count instead of
+            # OpenSearch's default 10,000 cap, so the paginated "count" is accurate.
+            search = self.document_class.search().query(query).extra(track_total_hits=True)
+
             # Apply filters from param_filters
             bool_match = params.get("bool_match")
             if bool_match == "true":

--- a/apps/deed/views.py
+++ b/apps/deed/views.py
@@ -1,7 +1,8 @@
 import copy
 from abc import abstractmethod
 
-from elasticsearch.dsl import Document, Q
+from opensearchpy import Q
+from django_opensearch_dsl import Document
 from rest_framework.decorators import action
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request

--- a/docs/modules/installation.rst
+++ b/docs/modules/installation.rst
@@ -64,34 +64,25 @@ The psql command will vary slightly with different OSes. For Mac:
 
     python manage.py createsuperuser
 
-7. For search to work properly, you will need to set up Elasticsearch locally in a Docker container. With Docker Desktop running, run the following command to start the Elasticsearch container:
+7. For search to work, run a local OpenSearch instance in Docker. With Docker Desktop running:
 
 .. code-block:: bash
 
-    curl -fsSL https://elastic.co/start-local | sh
+    docker run -d --name opensearch-dev \
+        -p 9200:9200 -p 9600:9600 \
+        -e "discovery.type=single-node" \
+        -e "DISABLE_SECURITY_PLUGIN=true" \
+        opensearchproject/opensearch:2
 
-The Elasticsearch API endpoint will be available at `http://127.0.0.1:9200/<http://127.0.0.1:9200/>`__ and the Kibana dashboard will be available at `http://127.0.0.1:5601/<http://127.0.0.1:5601/>`__.
+The OpenSearch API endpoint will be available at `http://127.0.0.1:9200/<http://127.0.0.1:9200/>`__. The ``DISABLE_SECURITY_PLUGIN`` flag keeps local setup simple by serving plain HTTP with no authentication; production uses an Amazon OpenSearch Service domain with fine-grained access control.
 
-8. Note the Elasticsearch authentication credentials in your terminal. They should look something like:
-
-.. code-block:: bash
-    🎉 Congrats, Elasticsearch and Kibana are installed and running in Docker!
-
-    🌐 Open your browser at http://localhost:5601
-
-    Username: elastic
-    Password: <password>
-
-    🔌 Elasticsearch API endpoint: http://localhost:9200
-    🔑 API key: <api_key>
-
-Create a new .env file in the root directory (i.e. outside of `racial_covenants_processor/` and next to the Pipfile):
+8. Create a new .env file in the root directory (i.e. outside of `racial_covenants_processor/` and next to the Pipfile):
 
 .. code-block:: bash
 
     cp .env.example .env
 
-Populate `ELASTICSEARCH_PASSWORD` and `ELASTICSEARCH_API_KEY` in the .env file using the credentials from the terminal output. Note: you may need to kill and restart your pipenv shell for the new environment variables to be available:
+Set ``OPENSEARCH_URL=http://localhost:9200`` in the .env file. For the local no-auth container above you can leave ``OPENSEARCH_PASSWORD`` blank; setting it (to any value locally, or the master-user password for an Amazon OpenSearch domain) is what enables real-time indexing on save. When it is unset, the index is populated only via the management commands in step 10. You may need to kill and restart your pipenv shell for the new environment variables to be available:
 
 .. code-block:: bash
 
@@ -106,8 +97,11 @@ Populate `ELASTICSEARCH_PASSWORD` and `ELASTICSEARCH_API_KEY` in the .env file u
 
 You can view the app at `http://127.0.0.1:8000/<http://127.0.0.1:8000/>`__.
 
-10. Any newly created records will be indexed on save. But, if you want to seed your database with a dump of the deployed database, you will need to run this command to index all those records:
+10. Seed the search index. After loading data (for example a dump of the deployed database), create the index and populate it:
 
 .. code-block:: bash
 
-    python manage.py search_index --rebuild
+    python manage.py opensearch index create
+    python manage.py opensearch document index
+
+``opensearch index rebuild`` deletes and recreates the index mapping but does not re-populate it, so follow it with ``opensearch document index``. Add ``--parallel`` to the document command to speed up bulk indexing of large datasets.

--- a/racial_covenants_processor/settings/common.py
+++ b/racial_covenants_processor/settings/common.py
@@ -60,7 +60,7 @@ INSTALLED_APPS = [
     "django_cotton",
     # 'django_extensions',
     # 'debug_toolbar',
-    'django_elasticsearch_dsl',
+    'django_opensearch_dsl',
 ]
 
 MIDDLEWARE = [
@@ -75,31 +75,34 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-_elasticsearch_default = {
-    "hosts": [os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")],
+_opensearch_default = {
+    "hosts": [os.environ.get("OPENSEARCH_URL", "http://localhost:9200")],
 }
-_elasticsearch_password = os.environ.get("ELASTICSEARCH_PASSWORD")
-if _elasticsearch_password:
-    _elasticsearch_default["basic_auth"] = ("elastic", _elasticsearch_password)
-
-ELASTICSEARCH_DSL = {"default": _elasticsearch_default}
-ELASTICSEARCH_DSL_INDEX_SETTINGS = {}
-ELASTICSEARCH_DSL_PARALLEL = False
-
-# Password set → local ES stack configured: real-time indexing. Unset → CI, tests, or
-# deployment without ES secrets: no signal-driven ES calls (use DB / management commands).
-if _elasticsearch_password:
-    ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = (
-        "django_elasticsearch_dsl.signals.RealTimeSignalProcessor"
+_opensearch_password = os.environ.get("OPENSEARCH_PASSWORD")
+if _opensearch_password:
+    # AWS OpenSearch fine-grained-access internal master user (or a local
+    # container's admin user). Username defaults to "admin"; override per env.
+    _opensearch_default["http_auth"] = (
+        os.environ.get("OPENSEARCH_USERNAME", "admin"),
+        _opensearch_password,
     )
-    ELASTICSEARCH_DSL_AUTOSYNC = True
-    ELASTICSEARCH_DSL_AUTO_REFRESH = True
+
+OPENSEARCH_DSL = {"default": _opensearch_default}
+OPENSEARCH_DSL_INDEX_SETTINGS = {}
+OPENSEARCH_DSL_PARALLEL = False
+
+# Password set → OpenSearch configured: real-time indexing. Unset → CI, tests, or
+# deployment without OpenSearch secrets: signal receivers are still wired but no-op,
+# because OPENSEARCH_DSL_AUTOSYNC=False makes registry update/delete early-return.
+# NOTE: do NOT point OPENSEARCH_DSL_SIGNAL_PROCESSOR at BaseSignalProcessor — it is
+# abstract in django-opensearch-dsl and cannot be instantiated (TypeError at boot).
+# Leave the default (RealTimeSignalProcessor) and gate behavior with AUTOSYNC.
+if _opensearch_password:
+    OPENSEARCH_DSL_AUTOSYNC = True
+    OPENSEARCH_DSL_AUTO_REFRESH = True
 else:
-    ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = (
-        "django_elasticsearch_dsl.signals.BaseSignalProcessor"
-    )
-    ELASTICSEARCH_DSL_AUTOSYNC = False
-    ELASTICSEARCH_DSL_AUTO_REFRESH = False
+    OPENSEARCH_DSL_AUTOSYNC = False
+    OPENSEARCH_DSL_AUTO_REFRESH = False
 
 ROOT_URLCONF = "racial_covenants_processor.urls"
 

--- a/racial_covenants_processor/settings/common.py
+++ b/racial_covenants_processor/settings/common.py
@@ -77,6 +77,12 @@ MIDDLEWARE = [
 
 _opensearch_default = {
     "hosts": [os.environ.get("OPENSEARCH_URL", "http://localhost:9200")],
+    # Bulk indexing over a network link (e.g. a VPC tunnel) to a single node can
+    # occasionally exceed opensearch-py's 10s default read timeout; raise it and
+    # retry transient timeouts so one slow batch doesn't abort a long index run.
+    "timeout": 60,
+    "max_retries": 5,
+    "retry_on_timeout": True,
 }
 _opensearch_password = os.environ.get("OPENSEARCH_PASSWORD")
 if _opensearch_password:

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,8 @@ django-storages==1.14.6; python_version >= '3.7'
 djangorestframework==3.16.1; python_version >= '3.9'
 djangorestframework-gis==1.2.0
 docutils==0.22.4; python_version >= '3.9'
-opensearch-py>=2.2.0,<3
+events==0.5
+opensearch-py==2.8.0
 executing==2.2.1; python_version >= '3.8'
 fastjsonschema==2.21.2
 fiona==1.10.1; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ django-appconf==1.2.0; python_version >= '3.9'
 django-compressor==4.6.0; python_version >= '3.10'
 django-cotton==2.6.1; python_version >= '3.8' and python_version < '4'
 django-debug-toolbar==6.2.0; python_version >= '3.10'
-django-elasticsearch-dsl==8.2
+django-opensearch-dsl==0.8.0
 django-extensions==4.1; python_version >= '3.9'
 django-filter==25.2; python_version >= '3.10'
 django-haystack==3.3.0
@@ -43,8 +43,7 @@ django-storages==1.14.6; python_version >= '3.7'
 djangorestframework==3.16.1; python_version >= '3.9'
 djangorestframework-gis==1.2.0
 docutils==0.22.4; python_version >= '3.9'
-elasticsearch==8.19.3
-elasticsearch-dsl==8.18.0
+opensearch-py>=2.2.0,<3
 executing==2.2.1; python_version >= '3.8'
 fastjsonschema==2.21.2
 fiona==1.10.1; python_version >= '3.8'


### PR DESCRIPTION
Swap django-elasticsearch-dsl / elasticsearch-py (8.x) for django-opensearch-dsl 0.8.0 + opensearch-py (<3) so the DeedPage search index can target AWS OpenSearch Service. The elasticsearch-py 8.x client enforces an X-Elastic-Product check that raises UnsupportedProductError against OpenSearch, so the prior stack could not connect to a domain at all.